### PR TITLE
Added attributes without values.

### DIFF
--- a/index.js
+++ b/index.js
@@ -173,6 +173,9 @@ function applyToToken (token, attrs) {
     } else if (m = attrs.match(/^\s*([a-zA-Z0-9\-\_]+)=([^ ]*)/)) {
       todo.push([ m[1], m[2] ])
       shift()
+    } else if (m = attrs.match(/^\s*([a-zA-Z0-9\-\_]+)/)) {
+      todo.push([ m[1], '' ])
+      shift()
     } else if (m = attrs.match(/^\s+/)) {
       shift()
     } else {
@@ -216,4 +219,3 @@ function spush (stack, token) {
   stack.types[type].push(token)
   stack.last = token
 }
-

--- a/test/test.js
+++ b/test/test.js
@@ -45,7 +45,7 @@ describe('markdown-it-decorate', function () {
     test('text\n\n<!--{#myid}-->\nhi', '<p id="myid">text</p>\n<p>hi</p>\n')
   })
 
-  describe('no attribute value:', function() {
+  describe('no attribute value:', function () {
     test('text <!--{data-foo}-->', '<p data-foo="">text</p>\n')
     test('text <!--{bar=}-->', '<p bar="">text</p>\n')
     test('text <!--{foo= bar}-->', '<p foo="" bar="">text</p>\n')

--- a/test/test.js
+++ b/test/test.js
@@ -45,11 +45,16 @@ describe('markdown-it-decorate', function () {
     test('text\n\n<!--{#myid}-->\nhi', '<p id="myid">text</p>\n<p>hi</p>\n')
   })
 
+  describe('no attribute value:', function() {
+    test('text <!--{data-foo}-->', '<p data-foo="">text</p>\n')
+    test('text <!--{bar=}-->', '<p bar="">text</p>\n')
+    test('text <!--{foo= bar}-->', '<p foo="" bar="">text</p>\n')
+    test('text <!--{#foo .bar baz booyah=}-->', '<p id="foo" class="bar" baz="" booyah="">text</p>\n')
+  })
+
   describe('falses:', function () {
     test('text <!--comment-->', '<p>text <!--comment--></p>\n')
     test('text\n<!--comment-->', '<p>text</p>\n<!--comment-->')
-    test('text\n<!--{#x aah}-->', '<p>text</p>\n<!--{#x aah}-->')
-    test('text <!--{#x aah}-->', '<p>text <!--{#x aah}--></p>\n')
     test('<!--{#x}-->', '<!--{#x}-->')
   })
 
@@ -68,6 +73,8 @@ describe('markdown-it-decorate', function () {
     test('text <!--{#x .y}-->', '<p id="x" class="y">text</p>\n')
     test('text <!--{#x .y z=1}-->', '<p id="x" class="y" z="1">text</p>\n')
     test('text [link](/) <!--{p: #x .y z=1}-->', '<p id="x" class="y" z="1">text <a href="/">link</a></p>\n')
+    test('text\n<!--{#x aah}-->', '<p id="x" aah="">text</p>\n')
+    test('text <!--{#x aah}-->', '<p id="x" aah="">text</p>\n')
   })
 
   describe('attributes', function () {


### PR DESCRIPTION
Quick and dirty, just adds the ability to add attributes without values (this is already supported in yours, but requires an `=` after the attribute, e.g. `<!-- {data-foo=} -->`). 

Mine allows an attribute without the `=` following the attribute (e.g. `<!-- {data-foo} -->`). Both convert to e.g. `<p data-foo="">`. I'd like to see them convert to e.g. `<p data-foo>`, but didn't find where you're adding the `=""` in concatenation yet. Your current setup requires attributes to have values, e.g. `m[2]` - mine is simply a blank string (`''`) for now. 